### PR TITLE
update for newer versions of CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,10 +83,10 @@ ExternalProject_Add(
   add_dependencies(kmc kmc_lib)
 
 
-find_library(pthread REQUIRED)
-find_library(z REQUIRED)
+find_package(Threads)
+find_package(ZLIB)
 
 add_executable(PloidyFrost ${SOURCES})
 
 
-target_link_libraries(PloidyFrost  pthread z  bifrost kmc )
+target_link_libraries(PloidyFrost  ${CMAKE_THREAD_LIBS_INIT} z  bifrost kmc )


### PR DESCRIPTION
This fixes an issue where newer (I believe after 3.14) versions of CMake can't use the current CMakelists.txt. 

I don't have an older version of CMake available (if I did, I wouldn't have needed to fix this) so I don't know if this works for them. 